### PR TITLE
Support /reels/ URL format in extract_instagram_shortcode

### DIFF
--- a/stats_for_dashboards/partnership_ads_booster.py
+++ b/stats_for_dashboards/partnership_ads_booster.py
@@ -49,6 +49,7 @@ def extract_instagram_shortcode(permalink: str) -> str:
 
     Handles two formats:
     1. Full URL: https://www.instagram.com/reel/aBc123XyZ/ -> aBc123XyZ
+       Also supports /reels/ URLs: https://www.instagram.com/reels/aBc123XyZ/
     2. Shortcode only: aBc123XyZ -> aBc123XyZ
 
     Args:
@@ -69,7 +70,7 @@ def extract_instagram_shortcode(permalink: str) -> str:
 
     # Check if it's a URL
     url_pattern = (
-        r"(?:https?://)?(?:www\.)?instagram\.com/(?:p|reel|tv)/([A-Za-z0-9_-]+)"
+        r"(?:https?://)?(?:www\.)?instagram\.com/(?:p|reels?|tv)/([A-Za-z0-9_-]+)"
     )
     match = re.search(url_pattern, permalink)
 

--- a/stats_for_dashboards/tests/test_partnership_ads_booster.py
+++ b/stats_for_dashboards/tests/test_partnership_ads_booster.py
@@ -26,6 +26,11 @@ class TestExtractInstagramShortcode:
         result = partnership_ads_booster.extract_instagram_shortcode(url)
         assert result == "jKl789MnO"
 
+    def test_extract_from_reels_url(self):
+        url = "https://www.instagram.com/reels/DVd0eJEESn9/"
+        result = partnership_ads_booster.extract_instagram_shortcode(url)
+        assert result == "DVd0eJEESn9"
+
     def test_extract_from_url_without_https(self):
         url = "instagram.com/reel/pQr012StU/"
         result = partnership_ads_booster.extract_instagram_shortcode(url)


### PR DESCRIPTION
- Updated regex from (p|reel|tv) to (p|reels?|tv) to match both /reel/ and /reels/ URL segments
- Added test case for https://www.instagram.com/reels/DVd0eJEESn9/