### PR TITLE
feat: add identities column to CSV input for partnership ads

### DIFF
--- a/stats_for_dashboards/partnership_ads_booster.py
+++ b/stats_for_dashboards/partnership_ads_booster.py
@@ -31,6 +31,10 @@ from typing import Dict, List, Optional, Tuple
 
 import requests
 
+# Maps CSV identities values to API ad_format integers
+# 1 = both identities (default), 2 = first identity only, 3 = dynamic optimization
+IDENTITIES_MAP = {"both": 1, "first": 2, "dynamic": 3}
+
 
 def get_ssl_verify_from_env() -> bool:
     """
@@ -679,6 +683,7 @@ def create_ad_creative(
     utm_parameters: Optional[str] = None,
     testimonial: Optional[str] = None,
     source_url: Optional[str] = None,
+    identities: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Create ad creative.
@@ -697,6 +702,9 @@ def create_ad_creative(
         utm_parameters: UTM parameters in query string format (optional)
         testimonial: Testimonial text for the ad (optional)
         source_url: Source URL for the creative (optional)
+        identities: Controls which identities to display in the ad (optional).
+            Values (case insensitive): BOTH (default), FIRST, DYNAMIC.
+            Maps to ad_format in branded_content: BOTH=1, FIRST=2, DYNAMIC=3.
 
     Returns:
         Tuple of (Creative ID or None, Error message or None)
@@ -729,6 +737,12 @@ def create_ad_creative(
         branded_content["instagram_boost_post_access_token"] = ad_code
     if testimonial:
         branded_content["testimonial"] = testimonial
+    if identities:
+        ad_format = IDENTITIES_MAP.get(identities.strip().lower())
+        if ad_format is not None:
+            branded_content["ad_format"] = ad_format
+        else:
+            print(f"Warning: Unknown identities value '{identities}', ignoring. Valid values: BOTH, FIRST, DYNAMIC")
 
     if branded_content:
         params["branded_content"] = json.dumps(branded_content)
@@ -879,6 +893,8 @@ def create_partnership_ads_from_csv(
     - utm_parameters (optional): UTM parameters in query string format (e.g., 'utm_source=instagram&utm_medium=paid')
     - testimonial (optional): Testimonial text for the ad
     - source_url (optional): Source URL for the creative
+    - identities (optional): Controls which identities to display in the ad.
+      Values (case insensitive): BOTH (default, both identities), FIRST (first identity only), DYNAMIC (system optimizes)
 
     Args:
         access_token: Facebook/Instagram access token
@@ -921,6 +937,7 @@ def create_partnership_ads_from_csv(
             utm_parameters = row.get("utm_parameters", "")
             testimonial = row.get("testimonial", "")
             source_url = row.get("source_url", "")
+            identities = row.get("identities", "")
 
             required_fields = {
                 "cta_type": cta_type,
@@ -1060,6 +1077,7 @@ def create_partnership_ads_from_csv(
                     utm_parameters if utm_parameters else None,
                     testimonial if testimonial else None,
                     source_url if source_url else None,
+                    identities if identities else None,
                 )
 
                 if not creative_id:

--- a/stats_for_dashboards/partnership_ads_ui.py
+++ b/stats_for_dashboards/partnership_ads_ui.py
@@ -329,6 +329,7 @@ def main():
             - `utm_parameters`: UTM parameters in query string format (e.g., `utm_source=instagram&utm_medium=paid`)
             - `testimonial`: Testimonial text for the ad
             - `source_url`: Source URL for the creative
+            - `identities`: Controls which identities to display in the ad. Values (case insensitive): `BOTH` (default, both identities), `FIRST` (first identity only), `DYNAMIC` (system optimizes)
 
             **Note:** Stories URLs are not supported and will be rejected.
             """

--- a/stats_for_dashboards/tests/test_partnership_ads_booster.py
+++ b/stats_for_dashboards/tests/test_partnership_ads_booster.py
@@ -1327,6 +1327,251 @@ class TestCreateAdCreative:
         assert creative_sourcing_spec["associated_product_set_id"] == "product_set_123"
         assert "degrees_of_freedom_spec" in params
 
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_identities_both(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that identities=BOTH sets ad_format=1 in branded_content"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            "test_ad_code",
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            identities="BOTH",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        assert "branded_content" in params
+        branded_content = json.loads(params["branded_content"])
+        assert branded_content["ad_format"] == 1
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_identities_first(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that identities=FIRST sets ad_format=2 in branded_content"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            "test_ad_code",
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            identities="FIRST",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        assert "branded_content" in params
+        branded_content = json.loads(params["branded_content"])
+        assert branded_content["ad_format"] == 2
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_identities_dynamic(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that identities=DYNAMIC sets ad_format=3 in branded_content"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            "test_ad_code",
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            identities="DYNAMIC",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        assert "branded_content" in params
+        branded_content = json.loads(params["branded_content"])
+        assert branded_content["ad_format"] == 3
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_identities_case_insensitive(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that identities values are case insensitive"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        for value in ["dynamic", "Dynamic", "DYNAMIC", " dynamic "]:
+            creative_id, error = partnership_ads_booster.create_ad_creative(
+                mock_access_token,
+                mock_ad_account_id,
+                mock_facebook_page_id,
+                mock_ig_account_id,
+                "media_123",
+                "test_ad_code",
+                "INSTALL_MOBILE_APP",
+                "https://app.link/install",
+                identities=value,
+            )
+
+            assert creative_id == "creative_123"
+            call_args = mock_post.call_args
+            branded_content = json.loads(call_args[1]["params"]["branded_content"])
+            assert branded_content["ad_format"] == 3, f"Failed for value: '{value}'"
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_identities_and_ad_code(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that ad_format coexists with instagram_boost_post_access_token in branded_content"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            "test_ad_code",
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            testimonial="Great product!",
+            identities="FIRST",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        branded_content = json.loads(params["branded_content"])
+        assert branded_content["instagram_boost_post_access_token"] == "test_ad_code"
+        assert branded_content["testimonial"] == "Great product!"
+        assert branded_content["ad_format"] == 2
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_identities_only_no_ad_code(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that branded_content is sent when only identities is provided (no ad_code, no testimonial)"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            None,  # no ad_code
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            identities="DYNAMIC",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        assert "branded_content" in params
+        branded_content = json.loads(params["branded_content"])
+        assert branded_content["ad_format"] == 3
+        assert "instagram_boost_post_access_token" not in branded_content
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_invalid_identities(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that invalid identities values are ignored and ad_format is not set"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            None,  # no ad_code
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            identities="INVALID_VALUE",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        # No branded_content should be set (no ad_code, no testimonial, invalid identities)
+        assert "branded_content" not in params
+
 
 class TestCreateAd:
     """Tests for create_ad function"""


### PR DESCRIPTION
Add optional 'identities' column to control which identities display in the ad via the branded_content ad_format API parameter.

CSV values (case insensitive):
- BOTH (default): renders both identities (ad_format=1)
- FIRST: renders only the first identity (ad_format=2)
- DYNAMIC: system auto-optimizes (ad_format=3)

Changes:
- Add IDENTITIES_MAP constant and identities param to create_ad_creative()
- Read identities from CSV in create_partnership_ads_from_csv()
- Update UI documentation in partnership_ads_ui.py
- Add 7 comprehensive tests covering all values, case insensitivity, coexistence with ad_code/testimonial, and invalid value handling