### PR TITLE
feat: add multi_advertiser_ads column to control multi-advertiser ads…

### DIFF
--- a/stats_for_dashboards/partnership_ads_booster.py
+++ b/stats_for_dashboards/partnership_ads_booster.py
@@ -684,6 +684,7 @@ def create_ad_creative(
     testimonial: Optional[str] = None,
     source_url: Optional[str] = None,
     identities: Optional[str] = None,
+    multi_advertiser_ads: Optional[str] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     """
     Create ad creative.
@@ -705,6 +706,9 @@ def create_ad_creative(
         identities: Controls which identities to display in the ad (optional).
             Values (case insensitive): BOTH (default), FIRST, DYNAMIC.
             Maps to ad_format in branded_content: BOTH=1, FIRST=2, DYNAMIC=3.
+        multi_advertiser_ads: Controls multi-advertiser ads enrollment (optional).
+            Values (case insensitive): OPT_OUT (to disable multi-advertiser ads),
+            OPT_IN (to enable, default behavior).
 
     Returns:
         Tuple of (Creative ID or None, Error message or None)
@@ -769,6 +773,14 @@ def create_ad_creative(
         creative_sourcing_spec["source_url"] = source_url
     if creative_sourcing_spec:
         params["creative_sourcing_spec"] = json.dumps(creative_sourcing_spec)
+
+    # Add contextual_multi_ads parameter to control multi-advertiser ads
+    if multi_advertiser_ads:
+        enroll_status = multi_advertiser_ads.strip().upper()
+        if enroll_status in ("OPT_OUT", "OPT_IN"):
+            params["contextual_multi_ads"] = json.dumps({"enroll_status": enroll_status})
+        else:
+            print(f"Warning: Unknown multi_advertiser_ads value '{multi_advertiser_ads}', ignoring. Valid values: OPT_OUT, OPT_IN")
 
     if utm_parameters:
         params["url_tags"] = utm_parameters
@@ -895,6 +907,8 @@ def create_partnership_ads_from_csv(
     - source_url (optional): Source URL for the creative
     - identities (optional): Controls which identities to display in the ad.
       Values (case insensitive): BOTH (default, both identities), FIRST (first identity only), DYNAMIC (system optimizes)
+    - multi_advertiser_ads (optional): Controls multi-advertiser ads enrollment.
+      Values (case insensitive): OPT_OUT (to disable multi-advertiser ads), OPT_IN (to enable, default behavior)
 
     Args:
         access_token: Facebook/Instagram access token
@@ -938,6 +952,7 @@ def create_partnership_ads_from_csv(
             testimonial = row.get("testimonial", "")
             source_url = row.get("source_url", "")
             identities = row.get("identities", "")
+            multi_advertiser_ads = row.get("multi_advertiser_ads", "")
 
             required_fields = {
                 "cta_type": cta_type,
@@ -1078,6 +1093,7 @@ def create_partnership_ads_from_csv(
                     testimonial if testimonial else None,
                     source_url if source_url else None,
                     identities if identities else None,
+                    multi_advertiser_ads if multi_advertiser_ads else None,
                 )
 
                 if not creative_id:

--- a/stats_for_dashboards/partnership_ads_ui.py
+++ b/stats_for_dashboards/partnership_ads_ui.py
@@ -330,6 +330,7 @@ def main():
             - `testimonial`: Testimonial text for the ad
             - `source_url`: Source URL for the creative
             - `identities`: Controls which identities to display in the ad. Values (case insensitive): `BOTH` (default, both identities), `FIRST` (first identity only), `DYNAMIC` (system optimizes)
+            - `multi_advertiser_ads`: Controls multi-advertiser ads enrollment. Values (case insensitive): `OPT_OUT` (to disable multi-advertiser ads), `OPT_IN` (to enable, default behavior)
 
             **Note:** Stories URLs are not supported and will be rejected.
             """

--- a/stats_for_dashboards/tests/test_partnership_ads_booster.py
+++ b/stats_for_dashboards/tests/test_partnership_ads_booster.py
@@ -1572,6 +1572,198 @@ class TestCreateAdCreative:
         # No branded_content should be set (no ad_code, no testimonial, invalid identities)
         assert "branded_content" not in params
 
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_multi_advertiser_ads_opt_out(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that multi_advertiser_ads=OPT_OUT sets contextual_multi_ads with enroll_status=OPT_OUT"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            None,  # no ad_code
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            multi_advertiser_ads="OPT_OUT",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        assert "contextual_multi_ads" in params
+        contextual_multi_ads = json.loads(params["contextual_multi_ads"])
+        assert contextual_multi_ads == {"enroll_status": "OPT_OUT"}
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_multi_advertiser_ads_opt_in(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that multi_advertiser_ads=OPT_IN sets contextual_multi_ads with enroll_status=OPT_IN"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            None,  # no ad_code
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            multi_advertiser_ads="OPT_IN",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        assert "contextual_multi_ads" in params
+        contextual_multi_ads = json.loads(params["contextual_multi_ads"])
+        assert contextual_multi_ads == {"enroll_status": "OPT_IN"}
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_multi_advertiser_ads_case_insensitive(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that multi_advertiser_ads values are case insensitive"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        test_cases = [
+            ("opt_out", "OPT_OUT"),
+            ("Opt_Out", "OPT_OUT"),
+            (" OPT_OUT ", "OPT_OUT"),
+            ("opt_in", "OPT_IN"),
+            ("Opt_In", "OPT_IN"),
+            (" OPT_IN ", "OPT_IN"),
+        ]
+
+        for input_value, expected_status in test_cases:
+            mock_post.reset_mock()
+            creative_id, error = partnership_ads_booster.create_ad_creative(
+                mock_access_token,
+                mock_ad_account_id,
+                mock_facebook_page_id,
+                mock_ig_account_id,
+                "media_123",
+                None,  # no ad_code
+                "INSTALL_MOBILE_APP",
+                "https://app.link/install",
+                multi_advertiser_ads=input_value,
+            )
+
+            assert creative_id == "creative_123"
+            assert error is None
+            call_args = mock_post.call_args
+            params = call_args[1]["params"]
+            assert "contextual_multi_ads" in params
+            contextual_multi_ads = json.loads(params["contextual_multi_ads"])
+            assert contextual_multi_ads == {"enroll_status": expected_status}
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_multi_advertiser_ads_and_other_params(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that multi_advertiser_ads works correctly with other parameters"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            "ad_code_123",  # ad_code
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            testimonial="Great product!",
+            identities="FIRST",
+            multi_advertiser_ads="OPT_OUT",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        # Check contextual_multi_ads is set
+        assert "contextual_multi_ads" in params
+        contextual_multi_ads = json.loads(params["contextual_multi_ads"])
+        assert contextual_multi_ads == {"enroll_status": "OPT_OUT"}
+        # Check branded_content has ad_format from identities
+        assert "branded_content" in params
+        branded_content = json.loads(params["branded_content"])
+        assert branded_content["ad_format"] == 2  # FIRST = 2
+
+    @patch("stats_for_dashboards.partnership_ads_booster.requests.post")
+    def test_create_creative_with_invalid_multi_advertiser_ads(
+        self,
+        mock_post,
+        mock_access_token,
+        mock_ad_account_id,
+        mock_facebook_page_id,
+        mock_ig_account_id,
+    ):
+        """Test that invalid multi_advertiser_ads values are ignored"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "creative_123"}
+        mock_post.return_value = mock_response
+
+        creative_id, error = partnership_ads_booster.create_ad_creative(
+            mock_access_token,
+            mock_ad_account_id,
+            mock_facebook_page_id,
+            mock_ig_account_id,
+            "media_123",
+            None,  # no ad_code
+            "INSTALL_MOBILE_APP",
+            "https://app.link/install",
+            multi_advertiser_ads="INVALID_VALUE",
+        )
+
+        assert creative_id == "creative_123"
+        assert error is None
+        call_args = mock_post.call_args
+        params = call_args[1]["params"]
+        # contextual_multi_ads should NOT be set for invalid value
+        assert "contextual_multi_ads" not in params
+
 
 class TestCreateAd:
     """Tests for create_ad function"""


### PR DESCRIPTION
… enrollment

- Add multi_advertiser_ads parameter to create_ad_creative() function
- Support OPT_OUT and OPT_IN values (case-insensitive) to control multi-advertiser ads
- When OPT_OUT is specified, adds contextual_multi_ads={"enroll_status": "OPT_OUT"} to API request
- Add CSV column support in create_partnership_ads_from_csv()
- Update UI documentation to include the new field
- Add comprehensive test coverage:
  - Test OPT_OUT sets contextual_multi_ads correctly
  - Test OPT_IN sets contextual_multi_ads correctly
  - Test case insensitivity (opt_out, Opt_Out, etc.)
  - Test combination with other parameters (identities, testimonial, ad_code)
  - Test invalid values are ignored

This allows users to disable multi-advertiser ads for partnership ad creatives by adding multi_advertiser_ads=OPT_OUT to their CSV input file.

Reference: https://developers.facebook.com/documentation/ads-commerce/marketing-api/creative/multi-advertiser-ads